### PR TITLE
try fix i18n no data

### DIFF
--- a/internal/appmgr/cache_for_api.go
+++ b/internal/appmgr/cache_for_api.go
@@ -252,6 +252,17 @@ func ReadCacheApplicationsWithMap(names []string) map[string]*models.Application
 
 	result := make(map[string]*models.ApplicationInfo)
 
+	// If names is an empty array, return all data
+	if len(names) == 0 {
+		for _, app := range cacheApplications {
+			copyApp := deepCopyApplication(app)
+			result[app.Name] = copyApp
+		}
+		glog.Infof("---------->on ReadCacheApplicationsWithMap: Returning all applications, count: %s", len(result))
+		return result
+	}
+
+	// Otherwise, return the specified applications by name
 	for _, name := range names {
 		for _, app := range cacheApplications {
 			if app.Name == name {
@@ -266,6 +277,27 @@ func ReadCacheApplicationsWithMap(names []string) map[string]*models.Application
 
 	return result
 }
+
+// func ReadCacheApplicationsWithMap(names []string) map[string]*models.ApplicationInfo {
+// 	mu.Lock() // Lock to ensure thread safety
+// 	defer mu.Unlock()
+
+// 	result := make(map[string]*models.ApplicationInfo)
+
+// 	for _, name := range names {
+// 		for _, app := range cacheApplications {
+// 			if app.Name == name {
+// 				copyApp := deepCopyApplication(app)
+// 				result[name] = copyApp
+// 				break
+// 			}
+// 		}
+// 	}
+
+// 	glog.Infof("---------->on ReadCacheApplicationsWithMap: %s", len(result))
+
+// 	return result
+// }
 
 func updateCacheI18n() {
 	for _, app := range cacheApplications {


### PR DESCRIPTION
In version 0.3.0, the introduction of the interface caching mechanism led to updates in several API implementations. However, the behavior regarding the names parameter being empty was not aligned with the previous method, resulting in data loss in the i18n interface. This commit addresses and fixes this issue.

Key Points:
- Version Update: The changes were made in version 0.3.0.
- Caching Mechanism: The new caching mechanism introduced modifications to API implementations.
- Parameter Handling: The handling of the names parameter when empty was inconsistent with the old method.
- Data Loss: This inconsistency caused data loss in the i18n interface.
- Fix: The current commit resolves this issue by aligning the new method's behavior with the old one.

This update ensures that the i18n interface functions correctly, preventing any further data loss due to parameter handling discrepancies.